### PR TITLE
update config settings and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,50 +12,117 @@ $ npm install --save-dev fastify-tsconfig
 
 Create your own `tsconfig.json` in the projects' root folder and extend it from `fastify-tsconfig`, overriding or adding the desired settings. By default, no `outDir` is set (because of [this issue](https://github.com/Microsoft/TypeScript/issues/29172)), so be sure to add one.
 
+### Configuration module and moduleResolution
+
+This configuration sets `"module"` and `"moduleResolution"` to [`NodeNext`](https://www.typescriptlang.org/docs/handbook/esm-node.html). This means that TypeScript will read the nearest `package.json` file in the scope and search for the `"type"` field or the absence of it.
+
+If `type` is not set or is `"type": "commonjs"` the emitted code will be CommonJS, with `.js` extension. Moreover, `tsc` will complain if ESM-only properties/features are used in source files. If you want to emit `.mjs` files, use the `.mts` extension.
+On the other hand, if `"type": "module"` is set, the sources will be compiled to the ESM with the `.js` extension. In this case, if you want to emit `.cjs` files, use the `.cts` extension for the source file.
+
+The "following the Node.js rules" goes also for the `package.json` `exports` field. If `type` is set, regardless of the value, TypeScript will check the `exports` field to know where the compiled code and the types are located. If the `type` field is not set, it will check for the `main` and `types` fields.
+
+#### CommonJS example
+`package.json`
+```jsonc
+{
+  "name": "my-package",
+  "type": "commonjs",
+  "main": "dist/index.js", // this is for older Node.js versions
+  "types": "dist/index.d.ts", // this is optional and can be omitted
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.js",
+    "types": "./dist/index.d.ts" // this is optional and can be omitted
+ }
+}
+```
+`tsconfig.json`
+```jsonc
+{
+ "extends": "fastify-tsconfig",
+ "compilerOptions": {
+    "outDir": "dist",
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}
+```
+#### ESM example
+`package.json`
+```jsonc
+{
+  "name": "my-package",
+  "type": "module",
+  "main": "dist/index.js", // this is for older Node.js versions
+  "types": "dist/index.d.ts", // this is optional and can be omitted
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.js",
+    "types": "./dist/index.d.ts" // this is optional and can be omitted
+ }
+}
+```
+`tsconfig.json`
+```jsonc
+{
+ "extends": "fastify-tsconfig",
+ "compilerOptions": {
+    "outDir": "dist",
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}
+```
+### Extending this configuration
+
 Depending on the type of the project, you should add the following settings.
 
-### Application
+#### Application
 `tsconfig.json`
 ```json
 {
  "extends": "fastify-tsconfig",
  "compilerOptions": {
- "outDir": "dist",
- "sourceMap": true
+    "outDir": "dist",
+    "sourceMap": true
  },
  "include": [
- "src/**/*.ts"
+    "src/**/*.ts"
  ]
 }
 ```
-### Package
+#### NPM Package
 `tsconfig.json`
 
 ```json
 {
  "extends": "fastify-tsconfig",
  "compilerOptions": {
- "outDir": "dist",
- "declaration": true
+    "outDir": "dist",
+    "declaration": true
  },
  "include": [
- "src/**/*.ts"
+    "src/**/*.ts"
  ]
 }
 ```
-### Monorepo Package
+#### Monorepo Package
 `tsconfig.json`
 
 ```json
 {
  "extends": "fastify-tsconfig",
  "compilerOptions": {
- "outDir": "dist",
- "declarationMap": true,
- "composite": true
+    "outDir": "dist",
+    "declarationMap": true,
+    "composite": true
  },
  "include": [
- "src/**/*.ts"
+    "src/**/*.ts"
  ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -10,18 +10,53 @@ $ npm install --save-dev fastify-tsconfig
 
 ## Usage
 
-Extend your own `tsconfig.json` file from `fastify-tsconfig` and override/add the desired settings. By default no `outDir` is set (because of [this issue](https://github.com/Microsoft/TypeScript/issues/29172)) , so be sure to add one.
+Create your own `tsconfig.json` in the projects' root folder and extend it from `fastify-tsconfig`, overriding or adding the desired settings. By default, no `outDir` is set (because of [this issue](https://github.com/Microsoft/TypeScript/issues/29172)), so be sure to add one.
 
+Depending on the type of the project, you should add the following settings.
+
+### Application
+`tsconfig.json`
+```json
+{
+ "extends": "fastify-tsconfig",
+ "compilerOptions": {
+ "outDir": "dist",
+ "sourceMap": true
+ },
+ "include": [
+ "src/**/*.ts"
+ ]
+}
+```
+### Package
 `tsconfig.json`
 
 ```json
 {
-  "extends": "fastify-tsconfig",
-  "compilerOptions": {
-    "outDir": "build",
-    "target": "es2018",
-    "lib": ["es2018"]
-  }
+ "extends": "fastify-tsconfig",
+ "compilerOptions": {
+ "outDir": "dist",
+ "declaration": true
+ },
+ "include": [
+ "src/**/*.ts"
+ ]
+}
+```
+### Monorepo Package
+`tsconfig.json`
+
+```json
+{
+ "extends": "fastify-tsconfig",
+ "compilerOptions": {
+ "outDir": "dist",
+ "declarationMap": true,
+ "composite": true
+ },
+ "include": [
+ "src/**/*.ts"
+ ]
 }
 ```
 
@@ -29,7 +64,7 @@ Check the other settings [here](./tsconfig.json)
 
 ## Configuration target
 
-The configuration targets es2018, that is supported in Node.js 10 and later. There is only one feature that is is missing from Node.js v10: [Proxy "ownKeys"](https://node.green/#ES2018) . However using es2018 as target makes some widely used features ("object rest properties", "object spread properties", and "Asynchronous Iterators") not being transpiled. To target some other version, just override `target` property.
+The configuration targets ES2022, which is supported in Node.js 16 and later. Only one feature still needs to be implemented: [RegExp Match Indices shows up in flags](https://node.green/#ES2022). However, using ES2022 as a target makes widely used features not being compiled. To target an older version, override the `target` property.
 
 ## License
 
@@ -38,3 +73,4 @@ Licensed under [MIT](./LICENSE).
 ---
 
 Inspired by: [sindresorhus/tsconfig](https://github.com/sindresorhus/tsconfig)
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-tsconfig",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Shared TypeScript configuration",
   "license": "MIT",
   "repository": {
@@ -14,7 +14,7 @@
   },
   "main": "tsconfig.json",
   "engines": {
-    "node": ">=10.4.0"
+    "node": ">=16.13.2"
   },
   "files": [
     "tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-tsconfig",
-  "version": "2.0.0",
+  "version": "1.0.1",
   "description": "Shared TypeScript configuration",
   "license": "MIT",
   "repository": {
@@ -14,7 +14,7 @@
   },
   "main": "tsconfig.json",
   "engines": {
-    "node": ">=16.13.2"
+    "node": ">=18.0.0"
   },
   "files": [
     "tsconfig.json"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,21 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "target": "es2018",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "declaration": true,
-    "pretty": true,
-    "noEmitOnError": true,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
     "strict": true,
     "resolveJsonModule": true,
     "removeComments": true,
     "newLine": "lf",
     "noUnusedLocals": true,
     "noFallthroughCasesInSwitch": true,
-    "useDefineForClassFields": true,
+    "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "lib": [
-      "esnext"
+      "ESNext"
     ]
   }
 }


### PR DESCRIPTION
This is a breaking change. 
- version bump to 2
- module and moduleResolution are set to NodeNext, which follows the Node.js ESM vs. CJS resolution (exports and main fields)
- adds more examples to readme based on the use case

#### Checklist

- [ ] ~run `npm run test` and `npm run benchmark`~
- [ ] ~tests and/or benchmarks are included~
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
